### PR TITLE
Add `<algorithm>` header to src/doctype.cpp

### DIFF
--- a/src/doctype.cpp
+++ b/src/doctype.cpp
@@ -28,6 +28,7 @@
 #include "mxml/error.hpp"
 #include "mxml/text.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <functional>
 #include <memory>


### PR DESCRIPTION
`std::find_if` and `std::find` need `<algorithm>` header. Without the header building fails.