### PR TITLE
Fix package name from `fastfloat` to `fast_float`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ try_compile(STD_CHARCONV_COMPILING
 if(NOT STD_CHARCONV_COMPILING)
 	message(NOTICE "mxml: Using fast_float for std::from_chars")
 	CPMFindPackage(
-		NAME fastfloat
+		NAME fast_float
 		GIT_REPOSITORY "https://github.com/fastfloat/fast_float"
 		GIT_TAG v8.0.2
 		EXCLUDE_FROM_ALL YES)


### PR DESCRIPTION
`fastfloat` causes the build to fail because the package cannot be found.

This pull request makes a minor update to the CMake configuration for the `fast_float` dependency. The change corrects the package name from `fastfloat` to `fast_float` in the `CPMFindPackage` call, ensuring the correct repository is referenced.

* Corrected the CMake package name from `fastfloat` to `fast_float` in the `CPMFindPackage` call in `CMakeLists.txt` to match the actual repository and package name.